### PR TITLE
Fix links to readme files as file extension changed

### DIFF
--- a/development/building.md
+++ b/development/building.md
@@ -8,10 +8,10 @@ sort_order: 2
 For help on getting the latest sources using Git, see [Cheat Sheet for Git](git-cheat-sheet.html)
 
 For build instructions specific to your platform, see one of the following files in the [top source directory](https://github.com/supercollider/supercollider):
-* [README_OS_X.txt](https://raw.github.com/supercollider/supercollider/master/README_OS_X.txt)
-* [README_LINUX.txt](https://raw.github.com/supercollider/supercollider/master/README_LINUX.txt)
-* [README_WINDOWS.txt](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.txt)
-* [README_IPHONE.txt](https://raw.github.com/supercollider/supercollider/master/README_IPHONE.txt)
+* [README_OS_X.md](https://raw.github.com/supercollider/supercollider/master/README_OS_X.md)
+* [README_LINUX.md](https://raw.github.com/supercollider/supercollider/master/README_LINUX.md)
+* [README_WINDOWS.md](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.md)
+* [README_IPHONE.md](https://raw.github.com/supercollider/supercollider/master/README_IPHONE.md)
 * etc...
 
 Building on embedded linux platforms (arm)


### PR DESCRIPTION
The links to the readme files are outdated as the extension changed from txt to md
