### PR TITLE
Remove ruby 2.0.0 strict version dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-ruby "2.0.0"
 
 gem 'github-pages'


### PR DESCRIPTION
According to the bundler docs - http://bundler.io/v1.5/gemfile_ruby.html - the ruby version directive is for strict binary compatibility, and is therefore too strict for our purposes. In fact we need any version of ruby which can run the github-pages gem, which is already enforced by the following line in the Gemfile.

Installing a particular sub-point revision of ruby is otherwise an unnecessary additional barrier to participation, no?