### PR TITLE
Update _config.yml to use pygments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@
 permalink: /:categories/:year/:month/:day/:title
 
 exclude: ["README.md", "Rakefile"]
-pygments: true
+highlighter: pygments
 
 #
 title: SuperCollider


### PR DESCRIPTION
I cannot test "on site" if this works. Locally for me it does (whereas pygments: true breaks)

Note: while pygments 2.1 does seem to contain a SC lexer, you do not get it via the gem "pygments.rb". Probably the pygments version contained is too old. Is there a way to know if the pygments used on the Github site already contains it?