### PR TITLE
Add fix for issues with tooltip in ide

### DIFF
--- a/development/building-raspberrypi.md
+++ b/development/building-raspberrypi.md
@@ -163,7 +163,7 @@ from raspbian desktop open a terminal and type:
 
   * `qjackctl`  #and select the usb soundcard under setup/interface.  click ok and start
   * `scide`  #in another terminal window to launch the supercollider ide
-  * `scide -style=gtkrc` #if the tooltips(popup hints) are illegible in the ide(white text on yellow background)
+  * `scide -style=gtkrc` #if the tooltips (popup hints) are illegible in the ide (white text on yellow background). workaround for issue [#1704](https://github.com/supercollider/supercollider/issues/1704)
   
 
 notes

--- a/development/building-raspberrypi.md
+++ b/development/building-raspberrypi.md
@@ -163,6 +163,8 @@ from raspbian desktop open a terminal and type:
 
   * `qjackctl`  #and select the usb soundcard under setup/interface.  click ok and start
   * `scide`  #in another terminal window to launch the supercollider ide
+  * `scide -style=gtkrc` #if the tooltips(popup hints) are illegible in the ide(white text on yellow background)
+  
 
 notes
 --


### PR DESCRIPTION
Add a line to step 4 of standard Raspbian Jessie install for users having issues with tooltip text being illegible (White text on yellow background).  By running "scide -style=gtkrc" Qt style is mapped to gtk standard colors and the white text becomes black. No other interface changes observed.  This is a workaround for a currently open issue in SC 3.7 and 3.8.