### PR TITLE
Give nav bar badges more room so they don't internally wrap

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,8 +52,8 @@
             {% assign group = 'navigation' %}
             {% include JB/pages_list %}
             <li><a href="http://doc.sccode.org/">Docs</a></li>
-            <li class="badges"><iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="120px" height="30px">watch</iframe>
-            <iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=fork&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="120px" height="30px">fork</iframe>
+            <li class="badges"><iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="105px" height="30px">watch</iframe>
+            <iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=fork&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="105px" height="30px">fork</iframe>
             </li>
           </ul>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,8 +52,8 @@
             {% assign group = 'navigation' %}
             {% include JB/pages_list %}
             <li><a href="http://doc.sccode.org/">Docs</a></li>
-            <li class="badges"><iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="90px" height="30px">watch</iframe>
-            <iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=fork&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="90px" height="30px">fork</iframe>
+            <li class="badges"><iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=watch&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="120px" height="30px">watch</iframe>
+            <iframe src="http://ghbtns.com/github-btn.html?user=supercollider&amp;repo=supercollider&amp;type=fork&amp;count=true&amp;size=small" allowtransparency="true" frameborder="0" scrolling="0" width="120px" height="30px">fork</iframe>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
<img width="852" alt="screen shot 2017-01-12 at 6 31 36 pm" src="https://cloud.githubusercontent.com/assets/15369640/21912665/5f8a0eec-d8f5-11e6-8638-b71614fef7b3.png">

This what the nav bar currently looks like for me on Firefox, Chrome, and Safari. I know there are bigger fish to fry but since this is a tiny design bug that could be easily fixed, I just did it quick as a way to get familiar with this repo. :)