### PR TITLE
Remove reference to current milestone

### DIFF
--- a/development/bugs.md
+++ b/development/bugs.md
@@ -126,7 +126,6 @@ Please be judicious about creating new labels - it's always better to find an ex
 
 
 # Milestones and versions
-The current SuperCollider milestone is 3.7.0. 
 
 SuperCollider milestones should follow the [semantic versioning standard](http://semver.org): **major.minor.patch**
 


### PR DESCRIPTION
There is no need to have this information here. It will constantly become outdated. Better to remove it.