### PR TITLE
Add link to wiki guides to Download page

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -58,15 +58,15 @@
                         provided by PlanetCCRMA
                     </li>
                 </ul>
-		Installation and Build Guides
-		<ul>
-		    <li>
-			<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>
-		    </li>
-		    <li>
-			<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu">Building SuperCollider from Source on Ubuntu</a>
-		    </li>
-		</ul>
+                Installation and Build Guides:
+                <ul>
+                    <li>
+                        <a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>
+                    </li>
+                    <li>
+                        <a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu">Building SuperCollider from Source on Ubuntu</a>
+                    </li>
+                </ul>
             </td>
             <td width="32%" valign="top">
                 <h2>

--- a/_includes/download.md
+++ b/_includes/download.md
@@ -58,6 +58,15 @@
                         provided by PlanetCCRMA
                     </li>
                 </ul>
+		Linux Installation and Build Guides
+		<ul>
+			<li>
+				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora"><strong>Installing SuperCollider on Fedora</strong></a>
+			</li>
+			<li>
+				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu"><strong>Building SuperCollider from Source on Ubuntu</strong></a>
+			</li>
+		</ul>
             </td>
             <td width="32%" valign="top">
                 <h2>

--- a/_includes/download.md
+++ b/_includes/download.md
@@ -58,7 +58,7 @@
                         provided by PlanetCCRMA
                     </li>
                 </ul>
-		Linux Installation and Build Guides
+		Installation and Build Guides
 		<ul>
 			<li>
 				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>

--- a/_includes/download.md
+++ b/_includes/download.md
@@ -45,7 +45,7 @@
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.8.0/SuperCollider-3.8.0-Source-linux.tar.bz2">Linux complete source code</a>
                         </li>
                 </ul>
-                 PPA and package distributions:
+                PPA and package distributions:
                 <ul>
                     <li>
                         <a href="http://launchpad.net/~supercollider/+archive/ppa"><strong>Ubuntu</strong> </a>
@@ -60,12 +60,12 @@
                 </ul>
 		Installation and Build Guides
 		<ul>
-			<li>
-				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>
-			</li>
-			<li>
-				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu">Building SuperCollider from Source on Ubuntu</a>
-			</li>
+		    <li>
+			<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>
+		    </li>
+		    <li>
+			<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu">Building SuperCollider from Source on Ubuntu</a>
+		    </li>
 		</ul>
             </td>
             <td width="32%" valign="top">

--- a/_includes/download.md
+++ b/_includes/download.md
@@ -61,10 +61,10 @@
 		Linux Installation and Build Guides
 		<ul>
 			<li>
-				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora"><strong>Installing SuperCollider on Fedora</strong></a>
+				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora">Installing SuperCollider on Fedora</a>
 			</li>
 			<li>
-				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu"><strong>Building SuperCollider from Source on Ubuntu</strong></a>
+				<a href="https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu">Building SuperCollider from Source on Ubuntu</a>
 			</li>
 		</ul>
             </td>


### PR DESCRIPTION
I feel it will be useful to add these links to the Download page. These guides are mostly correct (I modified the Fedora one just now, will look at Ubuntu next). At some point, we should add guides like these to the website. For now, they are works in progress, and keeping them in the Wiki makes them easier to modify and improve.