### PR TITLE
Downloads page: use dots instead of icons

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -100,14 +100,33 @@
 <br />
 
 <h2 id="beta-releases">Beta Releases</h2>
-<ul class="nodot"><li><a href="https://github.com/supercollider/supercollider/releases"><i class="icon-download-alt">&middot;</i>All Releases, including Beta Releases</a></li></ul>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/supercollider/releases">
+            All Releases, including Beta Releases
+        </a>
+    </li>
+</ul>
 
 <h2 id="building-from-source">Building from source</h2>
-<ul class="nodot"><li><a href="https://github.com/supercollider/supercollider"><i class="icon-download-alt">&middot;</i>Source Code</a></li></ul>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/supercollider">
+            Source Code
+        </a>
+    </li>
+</ul>
+
 <p>Build instructions are included with the source code. For more tips and trouble shooting check <a href="/development/building.html">this page</a>.</p>
 
 <h4>Plugins and Extensions</h4>
-<ul><li><a href="https://github.com/supercollider/sc3-plugins">Synthesis Plugins and Extensions</a></li></ul>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/sc3-plugins">
+            Synthesis Plugins and Extensions
+        </a>
+    </li>
+</ul>
 
 <h4>Quarks</h4>
 <p>Quarks is the package system and extends SuperCollider with lots of interesting things for math, graphics, machine learning, networking, interface and compositional frameworks.</p>


### PR DESCRIPTION
- Use dots for `ul` instead of icons - semantically, the download icon should only be used for links that will begin a download

- Expand out `ul`s to match formatting of the rest of the document