### PR TITLE
Improve Building From Source page

### DIFF
--- a/development/building.md
+++ b/development/building.md
@@ -19,4 +19,4 @@ Building on embedded linux platforms (arm)
 
 For building on [Raspberry Pi](http://www.raspberrypi.org) (raspbian) see [Bulding From Source on Raspberry Pi](building-raspberrypi.html).
 
-For building on [BeagleBone Black](http://beagleboard.org/Products/BeagleBone%20Black) (ubuntu/debian) see [Bulding From Source on BeagleBone Black](building-beagleboneblack.html).
+For building on [BeagleBone Black](http://beagleboard.org/Products/BeagleBone%20Black) (debian) see [Bulding From Source on BeagleBone Black](building-beagleboneblack.html).

--- a/development/building.md
+++ b/development/building.md
@@ -14,7 +14,7 @@ For build instructions specific to your platform, see one of the following files
 
 ### Community provided build guides  
 
-For building on **Ubuntu** see [Installing SuperCollider from source on Ubunut](https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu).
+For building on **Ubuntu** see [Installing SuperCollider from source on Ubuntu](https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu).
 
 For building on **Fedora** see [Installing SuperCollider on Fedora](https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora).
 

--- a/development/building.md
+++ b/development/building.md
@@ -12,9 +12,12 @@ For build instructions specific to your platform, see one of the following files
 * [README_LINUX.md](https://raw.github.com/supercollider/supercollider/master/README_LINUX.md)
 * [README_WINDOWS.md](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.md)
 
-Building on embedded linux platforms (arm)
-------------------------------------------
+### Community provided build guides  
 
-For building on [Raspberry Pi](http://www.raspberrypi.org) (raspbian) see [Bulding From Source on Raspberry Pi](building-raspberrypi.html).
+For building on **Ubuntu** see [Installing SuperCollider from source on Ubunut](https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-from-source-on-Ubuntu).
 
-For building on [BeagleBone Black](http://beagleboard.org/Products/BeagleBone%20Black) (debian) see [Bulding From Source on BeagleBone Black](building-beagleboneblack.html).
+For building on **Fedora** see [Installing SuperCollider on Fedora](https://github.com/supercollider/supercollider/wiki/Installing-SuperCollider-on-Fedora).
+
+For building on **Raspberry Pi** (raspbian) see [Bulding From Source on Raspberry Pi](building-raspberrypi.html).
+
+For building on **BeagleBone Black** (debian) see [Bulding From Source on BeagleBone Black](building-beagleboneblack.html).

--- a/development/building.md
+++ b/development/building.md
@@ -11,8 +11,6 @@ For build instructions specific to your platform, see one of the following files
 * [README_OS_X.md](https://raw.github.com/supercollider/supercollider/master/README_OS_X.md)
 * [README_LINUX.md](https://raw.github.com/supercollider/supercollider/master/README_LINUX.md)
 * [README_WINDOWS.md](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.md)
-* [README_IPHONE.md](https://raw.github.com/supercollider/supercollider/master/README_IPHONE.md)
-* etc...
 
 Building on embedded linux platforms (arm)
 ------------------------------------------

--- a/development/building.md
+++ b/development/building.md
@@ -8,7 +8,7 @@ sort_order: 2
 For help on getting the latest sources using Git, see [Cheat Sheet for Git](git-cheat-sheet.html)
 
 For build instructions specific to your platform, see one of the following files in the [top source directory](https://github.com/supercollider/supercollider):
-* [README_OS_X.md](https://raw.github.com/supercollider/supercollider/master/README_MACOS.md)
+* [README_MACOS.md](https://raw.github.com/supercollider/supercollider/master/README_MACOS.md)
 * [README_LINUX.md](https://raw.github.com/supercollider/supercollider/master/README_LINUX.md)
 * [README_WINDOWS.md](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.md)
 

--- a/development/building.md
+++ b/development/building.md
@@ -8,7 +8,7 @@ sort_order: 2
 For help on getting the latest sources using Git, see [Cheat Sheet for Git](git-cheat-sheet.html)
 
 For build instructions specific to your platform, see one of the following files in the [top source directory](https://github.com/supercollider/supercollider):
-* [README_OS_X.md](https://raw.github.com/supercollider/supercollider/master/README_OS_X.md)
+* [README_OS_X.md](https://raw.github.com/supercollider/supercollider/master/README_MACOS.md)
 * [README_LINUX.md](https://raw.github.com/supercollider/supercollider/master/README_LINUX.md)
 * [README_WINDOWS.md](https://raw.github.com/supercollider/supercollider/master/README_WINDOWS.md)
 


### PR DESCRIPTION
I felt the **Building From Source** page was in need of some love.

- Removed the mention of ubuntu with regards to BeagleBone Black (guide is for debian only).
- Removed link to iphone readme (gives the impression this is a supported platform)
- Remove "etc..."
- Renamed "Building on embedded linux ..." to "Community provided build guides"
- Added links to ubuntu and fedora guides from SC wiki 
- Removed links to Rpi and BBB websites and made names **bold**

**note** If anyone knows of a well written 3rd-party **macOS** or **Windows** build guide, please let me know.

Please review and suggest improvements ✨ 