### PR TITLE
Replace second front page example

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -153,6 +153,12 @@ code span.comment {
 	font-style: normal;
 }
 
+
+.main-page-examples code {
+    max-height: 20em;
+    overflow: auto;
+}
+
 /* responsive */
 @media (max-width: 1150px) {
 	.navbar .container-narrow {

--- a/index.md
+++ b/index.md
@@ -82,7 +82,7 @@ durations = [1, 1, 1, 1, 3/4, 1/4, 1/2, 3/4, 1/4, 1/2];
 Ppar([
     Pbind(*[
         instrument: \gabberkick,
-        amp: -10.dbamp,
+        amp: -15.dbamp,
         freq: 60,
         legato: 0.8,
         ffreq: Pseq((0..(durations.size * 4 - 1)).normalize, inf).linexp(0, 1, 100, 4000),
@@ -91,7 +91,7 @@ Ppar([
     ]),
     Pbind(*[
         instrument: \hoover,
-        amp: -7.dbamp,
+        amp: -12.dbamp,
         midinote: 74,
         dur: durations.sum * 2,
         sustain: 7,

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ group: index
 </div>
 
 
-<div class="row-fluid">
+<div class="row-fluid" class="main-page-examples">
 
   <h4>Examples</h4>
 
@@ -43,28 +43,60 @@ group: index
 
 
 {% highlight javascript %}
-// Simple synth definition using the Atari2600 UGen:
+// 60Hz Gabber Rave 1995
+Server.default.boot;
+
 (
-SynthDef(\atari2600, {|out= 0, gate= 1, tone0= 5,
-tone1= 8, freq0= 10, freq1= 20, amp= 1, pan= 0|
-  var e, z;
-  e= EnvGen.kr(Env.asr(0.01, amp, 0.05), gate, doneAction:2);
-  z= Atari2600.ar(tone0, tone1, freq0, freq1, 15, 15);
-  Out.ar(out, Pan2.ar(z * e, pan));
-}).add
+SynthDef(\gabberkick, {
+    var snd, freq, high, lfo;
+    freq = \freq.kr(440) * (Env.perc(0.001, 0.08, curve: -1).ar * 48 * \bend.kr(1)).midiratio;
+    snd = Saw.ar(freq);
+    snd = (snd * 100).tanh + ((snd.sign - snd) * -8.dbamp);
+    high = HPF.ar(snd, 300);
+    lfo = SinOsc.ar(8, [0, 0.5pi]).range(0, 0.01);
+    high = high.dup(2) + (DelayC.ar(high, 0.01, lfo) * -2.dbamp);
+    snd = LPF.ar(snd, 100).dup(2) + high;
+    snd = RLPF.ar(snd, 7000, 2);
+    snd = BPeakEQ.ar(snd, \ffreq.kr(3000) * XLine.kr(1, 0.8, 0.3), 0.5, 15);
+    snd = snd * Env.asr(0.001, 1, 0.05).ar(2, \gate.kr(1));
+    Out.ar(\out.kr(0), snd * \amp.kr(0.1));
+}).add;
+
+SynthDef(\hoover, {
+    var snd, freq, bw, delay, decay;
+    freq = \freq.kr(440);
+    freq = freq * Env([-5, 6, 0], [0.1, 1.7], [\lin, -4]).kr.midiratio;
+    bw = 1.035;
+    snd = { DelayN.ar(Saw.ar(freq * ExpRand(bw, 1 / bw)) + Saw.ar(freq * 0.5 * ExpRand(bw, 1 / bw)), 0.01, Rand(0, 0.01)) }.dup(20);
+    snd = (Splay.ar(snd) * 3).atan;
+    snd = snd * Env.asr(0.01, 1.0, 1.0).kr(0, \gate.kr(1));
+    snd = FreeVerb2.ar(snd[0], snd[1], 0.3, 0.9);
+    snd = snd * Env.asr(0, 1.0, 4, 6).kr(2, \gate.kr(1));
+    Out.ar(\out.kr(0), snd * \amp.kr(0.1));
+}).add;
 )
 
-// And a pattern to play it:
 (
-Pbind(
-  \instrument, \atari2600,
-  \dur, Pseq([0.25, 0.25, 0.25, 0.45], inf),
-  \amp, 0.8,
-  \tone0, Pseq([Pseq([2, 5], 32), Pseq([3, 5], 32)], inf),
-  \tone1, 14,
-  \freq0, Pseq([Pbrown(28, 31, 1, 32), Pbrown(23, 26, 3, 32)], inf),
-  \freq1, Pseq([Pn(10, 16), Pn(11, 16)], inf)
-).play
+var durations;
+durations = [1, 1, 1, 1, 3/4, 1/4, 1/2, 3/4, 1/4, 1/2];
+Ppar([
+    Pbind(*[
+        instrument: \gabberkick,
+        amp: -10.dbamp,
+        freq: 60,
+        legato: 0.8,
+        ffreq: Pseq((0..(durations.size * 4 - 1)).normalize, inf).linexp(0, 1, 100, 4000),
+        dur: Pseq(durations, inf),
+        bend: Pfuncn({ |x| if(x < (1/2), 0.4, 1) }, inf) <> Pkey(\dur),
+    ]),
+    Pbind(*[
+        instrument: \hoover,
+        amp: -7.dbamp,
+        midinote: 74,
+        dur: durations.sum * 2,
+        sustain: 7,
+    ])
+]).play(TempoClock(210 / 60));
 )
 {% endhighlight %}
 


### PR DESCRIPTION
This commit replaces the second front page example with a new original
one, titled "60 Hz Gabber Rave 1995." The previous example had to go
since it used the Atari2600 UGen, which is not in either core or
sc3-plugins.

The example is my original work. I release it under the public domain.