### PR TITLE
Remove link to Flickr SC group

### DIFF
--- a/index.md
+++ b/index.md
@@ -227,7 +227,6 @@ Ppar([
           <li><a href="https://www.facebook.com/groups/336468226443169/">SuperCollider Slovenija</a></li>
         </ul>
       </li>
-      <li><a href="http://flickr.com/groups/supercollider/pool/">flickr</a></li>
       <li><a href="http://www.vimeo.com/tag:supercollider">Vimeo</a></li>
       <li><a href="http://www.youtube.com/view_play_list?p=B813D0BDF50705D9">YouTube</a></li>
       <li><a href="https://lists.skylined.org/mailman/listinfo/supercollider">SuperCollider Slovenija mailing list</a></li>


### PR DESCRIPTION
The Flickr group shouldn't be linked to as a official social media page for SC. Nice photos though!