### PR TITLE
Remove redundant download link

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,6 @@ SuperCollider features three major components:
 SuperCollider was developed by James McCartney and originally released in 1996. In 2002, he generously released it as free software under the GNU General Public License. It is now maintained and developed by an active and enthusiastic community.
 
 
-- [Download](/download)
 - [Listen to some sounds](/examples/audio-examples)
 
 ## Examples


### PR DESCRIPTION
This link is too close to the top menu "Download" link to be useful. If we want the downloads to be more prominent, we should move the download section higher up. 