### PR TITLE
Use javascript highlighting for code examples

### DIFF
--- a/examples/supercollider-code-examples.md
+++ b/examples/supercollider-code-examples.md
@@ -9,7 +9,7 @@ sort_order: 2
 
 A babbling brook by [James McCartney 2007](http://www.listarc.bham.ac.uk/lists/sc-users-2007/msg02698.html).
 
-```supercollider
+```javascript
 { ({RHPF.ar(OnePole.ar(BrownNoise.ar, 0.99), LPF.ar(BrownNoise.ar, 14)
 * 400 + 500, 0.03, 0.003)}!2)
 + ({RHPF.ar(OnePole.ar(BrownNoise.ar, 0.99), LPF.ar(BrownNoise.ar, 20)


### PR DESCRIPTION
We still need to find a way to get SuperCollider code highlighting in markdown. For now, we can continue to use javascript.