### PR TITLE
Add JSON to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem 'json', '>=2.0'


### PR DESCRIPTION
Some Linux systems are unable to build the SC website locally due to Jekyll not finding JSON. The fix appears to be including 'json' in the site's Gemfile. I figure setting it to '>=2.0' will be fine.

