### PR TITLE
Download redesign

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -134,36 +134,3 @@
         </tr>
     </tbody>
 </table>
-<br />
-
-<h2 id="beta-releases">Releases</h2>
-<ul>
-    <li>
-        <a href="https://github.com/supercollider/supercollider/releases">SuperCollider Releases</a>
-        (including Stable Releases, Betas, and Release Candidates)
-    </li>
-</ul>
-
-<h2 id="building-from-source">Building from source</h2>
-<ul>
-    <li>
-        <a href="https://github.com/supercollider/supercollider">SuperCollider source on GitHub</a>
-    </li>
-</ul>
-
-<p>Build instructions are included in the source code, and can be found in the README corresponding to your system. These instructions, as well as some platform specific build guides, can also be found on the <a href="/development/building.html">Building from source</a> page.</p>
-
-<h2>Plugins and Extensions</h2>
-<ul>
-    <li>
-        <a href="https://github.com/supercollider/sc3-plugins">sc3-plugins</a>
-        <p>Extension plugins for the SuperCollider audio synthesis server. These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.</p>
-    </li>
-    <li>
-        <a href="https://github.com/supercollider-quarks/quarks">Quarks</a>
-        <p>Quarks are packages containing classes, extension methods, documentation and UGens. The integrated Quarks package system is used to download and manage these packages on your system.</p>
-        <p>On SuperCollider 3.7.0 or later, Quarks can be installed by graphical user interface, by GitHub URL, or by manually placing files in SuperCollider's Extensions folder. For more information, see the <a href="https://github.com/supercollider-quarks/quarks">SuperCollider-Quarks</a> project page.</p>
-        <h5 id="supercollider-3-6-and-earlier">NOTE: SuperCollider 3.6.6 and earlier</h5>
-        <p>See the old <a href="http://sourceforge.net/p/quarks/code/HEAD/tree/">SVN Quarks repository</a> and consult the help file included with your version of SuperCollider.</p>
-    </li>
-</ul>

--- a/css/main.css
+++ b/css/main.css
@@ -116,6 +116,7 @@ footer a.edit-link {
 #features ul {
 	font-size: 0.9em;
 }
+/*
 #download {
 	background: #f8f9e9;
 	background: #fff;
@@ -129,6 +130,7 @@ footer a.edit-link {
 	margin-left: 1em;
 	font-size: 0.9em;
 }
+*/
 
 /*  sc code highlighting */
 /* overide bootstrap box */

--- a/download.md
+++ b/download.md
@@ -4,4 +4,4 @@ title: Download
 group: navigation
 ---
 
-<div id="download">{% include download.md %}</div>
+{% include download.md %}

--- a/download.md
+++ b/download.md
@@ -5,3 +5,36 @@ group: navigation
 ---
 
 {% include download.md %}
+
+
+<h2 id="beta-releases">Releases</h2>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/supercollider/releases">SuperCollider Releases</a>
+        (including Stable Releases, Betas, and Release Candidates)
+    </li>
+</ul>
+
+<h2 id="building-from-source">Building from source</h2>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/supercollider">SuperCollider source on GitHub</a>
+    </li>
+</ul>
+
+<p>Build instructions are included in the source code, and can be found in the README corresponding to your system. These instructions, as well as some platform specific build guides, can also be found on the <a href="/development/building.html">Building from source</a> page.</p>
+
+<h2>Plugins and Extensions</h2>
+<ul>
+    <li>
+        <a href="https://github.com/supercollider/sc3-plugins">sc3-plugins</a>
+        <p>Extension plugins for the SuperCollider audio synthesis server. These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.</p>
+    </li>
+    <li>
+        <a href="https://github.com/supercollider-quarks/quarks">Quarks</a>
+        <p>Quarks are packages containing classes, extension methods, documentation and UGens. The integrated Quarks package system is used to download and manage these packages on your system.</p>
+        <p>On SuperCollider 3.7.0 or later, Quarks can be installed by graphical user interface, by GitHub URL, or by manually placing files in SuperCollider's Extensions folder. For more information, see the <a href="https://github.com/supercollider-quarks/quarks">SuperCollider-Quarks</a> project page.</p>
+        <h5 id="supercollider-3-6-and-earlier">NOTE: SuperCollider 3.6.6 and earlier</h5>
+        <p>See the old <a href="http://sourceforge.net/p/quarks/code/HEAD/tree/">SVN Quarks repository</a> and consult the help file included with your version of SuperCollider.</p>
+    </li>
+</ul>

--- a/index.md
+++ b/index.md
@@ -150,7 +150,8 @@ Ppar([
 - [Systems that interface with SuperCollider](community/systems-interfacing-with-sc.md)
 
 
-<div id="download">{% include download.md %}</div>
+### Download
+{% include download.md %}
 
 
 ### Community


### PR DESCRIPTION
This PR redesigns the `Download` page and changes the `_includes/download.md` to only contain the download links table. This makes the homepage download section more concise. 

The CSS styling related to `download` was commented out. This was causing a box to appear around markdown style headers called "Download". Also, I think it looks better without the box around the download section.

I can do the lower section of the Download page in markdown in a separate PR.