### PR TITLE
Fix links in tutorial/index.md

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -10,7 +10,7 @@ category: tutorials
 <li><a href="http://doc.sccode.org/Tutorials/Getting-Started/00-Getting-Started-With-SC.html">Getting started with SC</a> by Scott Wilson and James Harkins. This tutorial, as well as a <a href="http://doc.sccode.org/Browse.html#Tutorials">few others</a>, come bundled with SuperCollider's help system. <em>(there’s a <a href="http://jahya.net/blog/?2012-06-quickref-for-supercollider">quick reference</a> by Andrew McWilliams based on this tutorial)</em></li>
 <li><a href="https://ccrma.stanford.edu/~ruviaro/texts/A_Gentle_Introduction_To_SuperCollider.pdf">A Gentle Introduction to SuperCollider</a> by Bruno Ruviaro</li>
 <li><a href="http://composerprogrammer.com/teaching/supercollider/sctutorial/tutorial.html">Nick Collins’ &nbsp;SuperCollider tutorial</a> has a 12 week course of tutorial files as browseable HTML, and is also available in a downloadable zip</li>
-<li><a href="http://camil.music.illinois.edu/Classes/404A3/Documents/CottleSC3.pdf">Computer Music with examples in SuperCollider 3</a> by David Cottle</li>
+<li><a href="http://rhoadley.net/courses/tech_resources/supercollider/tutorials/cottle/CMSC7105.pdf">Computer Music with examples in SuperCollider 3</a> by David Cottle</li>
 <li><a href="https://www.youtube.com/playlist?list=PLPYzvS8A_rTaNDweXe6PX4CXSGq4iEWYC">SuperCollider Tutorials</a> on YouTube by Eli Fieldsteel</li>
 </ul>
 


### PR DESCRIPTION
I was browsing the tutorials page on the Supercollider site and noticed that the "Computer Music with examples in SuperCollider 3" by David Cottle led to a missing file. I found a new server that hosts the same file. This patch updates that link on the tutorial to point to the accessible file.

For reference:
[Old link](http://camil.music.illinois.edu/Classes/404A3/Documents/CottleSC3.pdf) (broken)
[New link](http://rhoadley.net/courses/tech_resources/supercollider/tutorials/cottle/CMSC7105.pdf)