### PR TITLE
Redo Wiki Community section ordering

### DIFF
--- a/community/code-of-conduct.md
+++ b/community/code-of-conduct.md
@@ -2,7 +2,7 @@
 layout: catpage
 title: Code of conduct
 category: community
-sort_order: 7
+sort_order: 1
 ---
 
 ## Purpose

--- a/community/mailing-lists.md
+++ b/community/mailing-lists.md
@@ -2,7 +2,7 @@
 layout: catpage
 title: Mailing Lists
 category: community
-sort_order: 1
+sort_order: 2
 ---
 
 Mailing list info at [www.birmingham.ac.uk/facilities/BEAST/research/supercollider/mailinglist.aspx](http://www.birmingham.ac.uk/facilities/BEAST/research/supercollider/mailinglist.aspx)

--- a/community/papers.md
+++ b/community/papers.md
@@ -3,7 +3,7 @@ layout: catpage
 title: "Academic Papers"
 description: ""
 category: "community"
-sort_order: 4
+sort_order: 7
 ---
 
 There have been many academic papers and book chapters published that discuss SuperCollider as a whole, or systems implemented in SuperCollider. This page is a stub – please add any academic papers relating to SuperCollider here.

--- a/community/sc140.md
+++ b/community/sc140.md
@@ -3,7 +3,7 @@ layout: catpage
 title: "sc140"
 description: ""
 category: "community"
-sort_order: 6
+sort_order: 5
 ---
 ### sc140
 

--- a/community/supercollider-symposium.md
+++ b/community/supercollider-symposium.md
@@ -3,7 +3,7 @@ layout: catpage
 title: "SuperCollider Symposium"
 description: ""
 category: "community"
-sort_order: 2
+sort_order: 6
 ---
 The **SuperCollider Symposium** is an international gathering of SuperCollider users and developers. The symposium happens on an irregular basis in different cities around the world. The following is a complete list of the symposia that have taken place.
 

--- a/community/systems-interfacing-with-sc.md
+++ b/community/systems-interfacing-with-sc.md
@@ -3,7 +3,7 @@ layout: catpage
 title: "Systems interfacing with SC"
 description: ""
 category: "community"
-sort_order: 5
+sort_order: 4
 ---
 
 


### PR DESCRIPTION
On the _Wiki_ page, the __Community__ section will now list pages in the following order:

* Community
   * Code of conduct
    * Mailing Lists
    * blogs and sites
    * Systems interfacing with SC
    * sc140
    * SuperCollider Symposium
    * Academic Papers

The main difference is that the CoC is up top, followed by the mailing list. There's no ideal ordering for the rest of the pages, I think.
    
