### PR TITLE
raspberry headless update instructions for 3.10

### DIFF
--- a/development/building-raspberrypi.md
+++ b/development/building-raspberrypi.md
@@ -36,7 +36,7 @@ step3 (compile and install supercollider)
 --
 1. `git clone --recursive git://github.com/supercollider/supercollider`
 2. `cd supercollider`
-3. `git checkout 3.9`  #use latest version 3.9.x on branch 3.9
+3. `git checkout 3.9`  #use latest version 3.9.x on branch 3.9 (NOTE 3.10 does not currently compile on stretch due to issue with Qt5WebEngine)
 4. `git submodule init && git submodule update`
 5. `mkdir build && cd build`
 6. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DSUPERNOVA=OFF -DNATIVE=ON -DSC_WII=ON -DSC_IDE=ON -DSC_QT=ON -DSC_ED=OFF -DSC_EL=OFF -DSC_VIM=ON ..`
@@ -79,7 +79,7 @@ Compiling SC natively on Raspberry Pi Raspbian Lite
 ==
 note: this section is for more advanced users that want to compile and run supercollider (sclang+scsynth) under **raspbian stretch lite**. it does not include qt nor the ide.
 
-the instructions here are meant for supercollider version 3.9.1 and higher; for instructions on building previous versions please see older versions of this page or ask on the mailing list.
+the instructions here are meant for supercollider version 3.10 and higher; for instructions on building previous versions please see older versions of this page or ask on the mailing list.
 
 requirements
 --
@@ -103,7 +103,7 @@ step2 (update the system, install required libraries)
 3. `sudo apt-get update`
 4. `sudo apt-get upgrade`
 5. `sudo apt-get dist-upgrade`
-6. `sudo apt-get install libsamplerate0-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev libcwiid-dev cmake git`
+6. `sudo apt-get install libsamplerate0-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline-dev libfftw3-dev libudev-dev cmake git`
 
 step3 (compile & install jackd (no d-bus) )
 --
@@ -115,36 +115,24 @@ step3 (compile & install jackd (no d-bus) )
 6. `sudo ldconfig`
 7. `cd ..`
 8. `rm -rf jack2`
-9. `sudo nano /etc/security/limits.conf`  #and add the following lines at the end...
+9. `sudo sh -c "echo @audio - memlock 256000 >> /etc/security/limits.conf"`
+10. `sudo sh -c "echo @audio - rtprio 75 >> /etc/security/limits.conf"`
+11. `echo /usr/local/bin/jackd -P75 -p16 -dalsa -dhw:0 -r44100 -p1024 -n3 > ~/.jackdrc`
+12. `exit` #and ssh in again to make the limits.conf settings work
         
-        @audio - memlock 256000
-        @audio - rtprio 75
-        
-10. `exit`  #and ssh in again to make the limits.conf settings work
-11. `nano ~/.jackdrc`  #edit to look like this...
-        
-        /usr/local/bin/jackd -P75 -dalsa -dhw:0 -r44100 -p1024 -n3
-        
-the `-dhw:0` above is the internal soundcard. change this to `-dhw:1` for usb soundcards. `aplay -l` will list available devices.
+the `-dhw:0` above is the internal soundcard. change this to `-dhw:1` for usb soundcards. `aplay -l` will list available devices. use `nano ~/.jackdrc` to edit jack settings.
 
 step4 (compile & install supercollider)
 --
 1. `git clone --recursive git://github.com/supercollider/supercollider`
 2. `cd supercollider`
-3. `git checkout 3.9`  #use latest version 3.9.x on branch 3.9
+3. `git checkout 3.10`  #use latest version 3.10.x on branch 3.10
 4. `git submodule init && git submodule update`
-5. `nano lang/LangSource/SC_TerminalClient.cpp`  #TEMP FIX for 100% sclang issue - find the first line and comment it out, add the 2nd right after
-        
-        //mTimer.cancel();
-        if (error==boost::system::errc::success) {mTimer.cancel();} else {return;}
-        
-6. `mkdir build && cd build`
-7. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DSUPERNOVA=OFF -DNATIVE=ON -DSC_WII=ON -DSC_IDE=OFF -DSC_QT=OFF -DSC_ED=OFF -DSC_EL=OFF -DSC_VIM=ON ..`
+5. `mkdir build && cd build`
+6. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DSUPERNOVA=OFF -DNATIVE=ON -DSC_IDE=OFF -DNO_X11=ON -DSC_QT=OFF -DSC_ED=OFF -DSC_EL=OFF -DSC_VIM=ON ..`
 8. `make -j 4`  #use -j4 flag only for rpi3 (quadcore)
 9. `sudo make install`
 10. `sudo ldconfig`
-11. The following command can be skipped if using SC 3.9.2 and higher:  
-`mkdir -p ~/.config/SuperCollider`
 
 startup
 --
@@ -159,12 +147,15 @@ when you boot the server jack should start automatically with the settings in `~
 sc3-plugins
 ==
 how to compile and install [sc3-plugins](https://github.com/supercollider/sc3-plugins). this applies to both the scide and lite versions above.
-1. `git clone --recursive https://github.com/supercollider/sc3-plugins.git --depth 1`
-2. `cd sc3-plugins`
-3. `mkdir build && cd build`
-4. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DSUPERNOVA=OFF -DNATIVE=ON -DSC_PATH=../../supercollider/ ..`
-5. `make -j 4`  #use -j4 flag only for rpi3 (quadcore)
-6. `sudo make install`
+1. `cd ~`
+2. `git clone --recursive https://github.com/supercollider/sc3-plugins.git`
+3. `cd sc3-plugins`
+4. `git checkout 3.10`
+5. `git submodule init && git submodule update`
+6. `mkdir build && cd build`
+7. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DSUPERNOVA=OFF -DNATIVE=ON -DSC_PATH=../../supercollider/ ..`
+8. `make -j 4`  #use -j4 flag only for rpi3 (quadcore)
+9. `sudo make install`
 
 autostart
 ==
@@ -172,7 +163,7 @@ how to automatically run supercollider code at system boot. this applies to both
 1. `nano ~/autostart.sh`  #and add the following lines (ctrl+o, ctrl+x to save and exit)...
         
         #!/bin/bash
-        PATH=/usr/local/bin:$PATH
+        export PATH=/usr/local/bin:$PATH
         export DISPLAY=:0.0
         sleep 10  #can be lower (5) for rpi3
         sclang mycode.scd

--- a/development/building-raspberrypi.md
+++ b/development/building-raspberrypi.md
@@ -30,7 +30,7 @@ from raspbian desktop open a terminal window and type...
 2. `sudo apt-get update`
 3. `sudo apt-get upgrade`
 4. `sudo apt-get dist-upgrade`
-5. `sudo apt-get install libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev libcwiid-dev cmake qttools5-dev-tools libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev`
+5. `sudo apt-get install libjack-jackd2-dev libsndfile1-dev libasound2-dev libavahi-client-dev libreadline6-dev libfftw3-dev libxt-dev libudev-dev libcwiid-dev cmake qttools5-dev-tools libqt5webkit5-dev qtpositioning5-dev libqt5sensors5-dev qjackctl`
 
 step3 (compile and install supercollider)
 --

--- a/development/building-raspberrypi.md
+++ b/development/building-raspberrypi.md
@@ -36,7 +36,7 @@ step3 (compile and install supercollider)
 --
 1. `git clone --recursive git://github.com/supercollider/supercollider`
 2. `cd supercollider`
-3. `git checkout 3.9`  #use latest version 3.9.x on branch 3.9 (NOTE 3.10 does not currently compile on stretch due to issue with Qt5WebEngine)
+3. `git checkout Version-3.9.3`  #use 3.9.3 (NOTE 3.10 does not currently compile on stretch due to issue with Qt5WebEngine)
 4. `git submodule init && git submodule update`
 5. `mkdir build && cd build`
 6. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DSUPERNOVA=OFF -DNATIVE=ON -DSC_WII=ON -DSC_IDE=ON -DSC_QT=ON -DSC_ED=OFF -DSC_EL=OFF -DSC_VIM=ON ..`
@@ -126,7 +126,7 @@ step4 (compile & install supercollider)
 --
 1. `git clone --recursive git://github.com/supercollider/supercollider`
 2. `cd supercollider`
-3. `git checkout 3.10`  #use latest version 3.10.x on branch 3.10
+3. `git checkout master`  #use latest stable release (3.10 at the time of writing)
 4. `git submodule init && git submodule update`
 5. `mkdir build && cd build`
 6. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DBUILD_TESTING=OFF -DSUPERNOVA=OFF -DNATIVE=ON -DSC_IDE=OFF -DNO_X11=ON -DSC_QT=OFF -DSC_ED=OFF -DSC_EL=OFF -DSC_VIM=ON ..`
@@ -150,12 +150,10 @@ how to compile and install [sc3-plugins](https://github.com/supercollider/sc3-pl
 1. `cd ~`
 2. `git clone --recursive https://github.com/supercollider/sc3-plugins.git`
 3. `cd sc3-plugins`
-4. `git checkout 3.10`
-5. `git submodule init && git submodule update`
-6. `mkdir build && cd build`
-7. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DSUPERNOVA=OFF -DNATIVE=ON -DSC_PATH=../../supercollider/ ..`
-8. `make -j 4`  #use -j4 flag only for rpi3 (quadcore)
-9. `sudo make install`
+4. `mkdir build && cd build`
+5. `cmake -L -DCMAKE_BUILD_TYPE="Release" -DSUPERNOVA=OFF -DNATIVE=ON -DSC_PATH=../../supercollider/ ..`
+6. `make -j 4`  #use -j4 flag only for rpi3 (quadcore)
+7. `sudo make install`
 
 autostart
 ==


### PR DESCRIPTION
scide instructions still on 3.9 because of qtwebengine5  issue with raspbian stretch https://github.com/supercollider/supercollider/issues/4010