### PR TITLE
[WIP] Update downloads page for 3.10.0

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -8,25 +8,19 @@
                 <h4>Current Version</h4>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-macOS.zip"><i class="icon-download-alt">.</i> 3.9.3</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.0/SuperCollider-3.10.0-macOS.zip"><i class="icon-download-alt">.</i> 3.10.0</a>
                     </li>
                 </ul>
                 <h4>Previous Releases</h4>
                 <ul class="nodot">
                     <li>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-macOS.zip"><i class="icon-download-alt">.</i> 3.9.3</a>
+                    </li>
+                    <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.8.1/SuperCollider-3.8.1-MacOS.zip"><i class="icon-download-alt">.</i> 3.8.1</a>
                     </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.7.2/SuperCollider-OSX-3.7.2.zip"><i class="icon-download-alt">.</i> 3.7.2</a>
-                    </li>
-                    <li>
-                        <a href="http://sourceforge.net/projects/supercollider/files/Mac%20OS%20X/3.6/SuperCollider-3.6.6-OSX.dmg/download"><i class="icon-download-alt">.</i> 3.6.6</a> (OS X 10.6 32/64-bit)
-                    </li>
-                    <li>
-                        <a href="http://sourceforge.net/projects/supercollider/files/Mac%20OS%20X/3.6/SuperCollider-3.6.5-OSX-universal-no-ide.dmg/download"><i class="icon-download-alt">.</i> 3.6.5</a> (old Cocoa IDE)
-                    </li>
-                    <li>
-                        <a href="http://sourceforge.net/projects/supercollider/files/Mac%20OS%20X/3.4.4/SuperCollider-3.4.4_32_bit.dmg/download"><i class="icon-download-alt">.</i> 3.4.4</a> (OSX 10.4, 32-bit universal build)
                     </li>
                 </ul>
                 <h4>Bleeding Edge</h4>
@@ -46,7 +40,7 @@
                 </h4>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-Source-linux.tar.bz2">3.9.3 source tarball</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.0/SuperCollider-3.10.0-Source-linux.tar.bz2">3.10.0 source tarball</a>
                     </li>
                 </ul>
                 <h4>
@@ -85,39 +79,33 @@
                     Windows
                 </h2>
                 <h4>Current Version</h4>
-                <h5>64-bit</h5>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-Windows-x64-VS.exe"><i class="icon-download-alt">.</i> 3.9.3</a> (no SuperNova)<br />
-                        <a href="https://github.com/supercollider/sc3-plugins/releases/download/Version-3.9.0/sc3-plugins-3.9.0-Windows-x64-VS.zip"><i class="icon-download-alt">.</i> sc3-plugins 3.9.0</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.0/SuperCollider-3.10.0-Windows-x64-VS.exe"><i class="icon-download-alt">.</i> 3.10.0, 64-bit</a> (no SuperNova)<br />
                     </li>
-                </ul>
-                <h5>32-bit</h5>
-                <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-Windows-x86-VS.exe"><i class="icon-download-alt">.</i> 3.9.3</a> (no SuperNova)<br />
-                        <a href="https://github.com/supercollider/sc3-plugins/releases/download/Version-3.9.0/sc3-plugins-3.9.0-Windows-x86-VS.zip"><i class="icon-download-alt">.</i> sc3-plugins 3.9.0</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.0/SuperCollider-3.10.0-Windows-x86-VS.exe"><i class="icon-download-alt">.</i> 3.10.0, 32-bit</a> (no SuperNova)<br />
                     </li>
                 </ul>
                 <h4>Previous releases</h4>
                 <ul class="nodot">
                     <li>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-Windows-x64-VS.exe"><i class="icon-download-alt">.</i> 3.9.3, 64-bit</a> (no SuperNova)<br />
+                    </li>
+                    <li>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.9.3/SuperCollider-3.9.3-Windows-x86-VS.exe"><i class="icon-download-alt">.</i> 3.9.3, 32-bit</a> (no SuperNova)<br />
+                    </li>
+                    <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.8.1/SuperCollider-3.8.1-Windows-x64-VS.exe"><i class="icon-download-alt">.</i> 3.8.1, 64-bit</a> (no SuperNova)<br />
-                        <a href="https://github.com/supercollider/sc3-plugins/releases/download/Version-3.8.0/sc3-plugins_Windows_SC3.8_VS-64bit_692f92f.zip"><i class="icon-download-alt">.</i> sc3-plugins 3.8.0, 64-bit</a>
                     </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.8.0/SuperCollider-3.8.0_Windows_32bits_MW_SuperNova_0947edd.exe"><i class="icon-download-alt">.</i> 3.8.0, 32-bit</a> (with SuperNova)<br />
-                        <a href="https://github.com/supercollider/sc3-plugins/releases/download/Version-3.8.0/sc3-plugins_Windows_SC3.8_MW-32bit_incl-SuperNova_692f92f.zip"><i class="icon-download-alt">.</i> sc3-plugins 3.8.0, 32-bit</a>
                     </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.8.0/SuperCollider-3.8.0_Windows_32bits_VS_Sonic_Pi_0947edd.exe"><i class="icon-download-alt">.</i> 3.8.0, 32-bit</a> (no SuperNova, Sonic Pi build)<br />
-                        <a href="https://github.com/supercollider/sc3-plugins/releases/download/Version-3.8.0/sc3-plugins_Windows_SC3.8_VS-32bit_SonicPi_692f92f.zip"><i class="icon-download-alt">.</i> sc3-plugins 3.8.0, 32-bit</a>
                     </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.7.2/SuperCollider-3.7.2_Release-win32-MinGW-abfba5b.exe"><i class="icon-download-alt">.</i> 3.7.2</a> (with SuperNova, Win XP)<br />
-                    </li>
-                    <li>
-                        <a href="http://sourceforge.net/projects/supercollider/files/Windows/3.6/SuperCollider-3.6.6-win32.exe/download"><i class="icon-download-alt">.</i> 3.6.6</a> (Win 2000)
                     </li>
                 </ul>
                 <h4>Bleeding Edge</h4>

--- a/_posts/2018-11-25-supercollider-3.10.0.md
+++ b/_posts/2018-11-25-supercollider-3.10.0.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: "SuperCollider 3.10.0"
+description: "SuperCollider 3.10.0 now available"
+category: Releases
+author: brianlheim
+tags: []
+---
+
+TODO

--- a/_posts/2018-11-25-supercollider-3.10.0.md
+++ b/_posts/2018-11-25-supercollider-3.10.0.md
@@ -7,4 +7,28 @@ author: brianlheim
 tags: []
 ---
 
-TODO
+We are proud to announce the release of SuperCollider 3.10! It's been an arduous process; we've come
+a long way, and we'll continue to polish things up in backward-compatible 3.10.x patch releases. We
+hope you enjoy the countless new features and fixes contributed by our fantastic development
+community.
+
+Some of the more notable changes in this version include:
+
+- Major UI updates to the IDE, including a better default theme and new built-in themes such as
+  Solarized Light and Dark
+- SerialPort is now available on Windows
+- The Supernova server is now available in the release package for macOS
+- Breaking change: Float:asString now always produces a decimal point, so 3.0.asString is now "3.0"
+  instead of "3".
+- Lots (100+) of new math functions are available in sclang
+- Menu GUI components are available in sclang
+- Fixed high CPU usage by sclang when built without Qt
+- Fixes for file path encoding issues on Windows
+- The web view backend used in the IDE help browser and WebView class changed from QWebKit to
+  QWebEngine, which means the project now builds with Qt >= 5.7
+- The project now supports building with Windows Visual Studio >= 2015
+
+Check out "News in 3.10" in the IDE or the [full changelog](https://github.com/supercollider/supercollider/blob/Version-3.10.0/CHANGELOG.md)
+for more information.  You can grab the latest version from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.10.0).
+
+Thanks for using SuperCollider!

--- a/download.md
+++ b/download.md
@@ -7,23 +7,19 @@ group: navigation
 {% include download.md %}
 
 ### Releases
-[SuperCollider Releases](https://github.com/supercollider/supercollider/releases) (including Stable Releases, Betas, and Release Candidates)
+<a href="https://github.com/supercollider/supercollider/releases" target="_blank">SuperCollider Releases</a> (including Stable Releases, Betas, and Release Candidates)
 
 ### Building from source
-[SuperCollider source on Github](https://github.com/supercollider/supercollider)
+<a href="https://github.com/supercollider/supercollider" target="_blank">SuperCollider source on GitHub</a>
 
 Build instructions are included in the source code, and can be found in the README corresponding to your system. These instructions, as well as some platform specific build guides, can also be found on the [Building from source](/development/building.html) page.
 
 ### Plugins and Extensions
 
-- [sc3plugins](https://github.com/supercollider/sc3-plugins)
+- <a href="https://supercollider.github.io/sc3-plugins/" target="_blank">sc3-plugins</a>
 
-    The sc3plugins are extension plugins for the SuperCollider audio synthesis server. These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.
+    The sc3-plugins are extension plugins for the SuperCollider audio synthesis server. These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.
 
-- [Quarks](https://github.com/supercollider-quarks/quarks)
+- <a href="https://github.com/supercollider-quarks/quarks" target="_blank">Quarks</a>
 
     Quarks are packages containing classes, extension methods, documentation and UGens. The integrated Quarks package system is used to download and manage these packages on your system.
-
-    **[SuperCollider 3.7.0 or later]** Quarks can be installed by graphical user interface, by GitHub URL, or by manually placing files in SuperCollider's Extensions folder. For more information, see the [SuperCollider Quarks](https://github.com/supercollider-quarks/quarks) project page.
-
-    **[SuperCollider 3.6.6 and earlier]** See the old [SVN Quarks repository](http://sourceforge.net/p/quarks/code/HEAD/tree/) and consult the help file included with your version of SuperCollider.


### PR DESCRIPTION
- remove sc3-plugins from windows downloads (link is on page)
- remove versions before 3.7.2 from download links
- remove info about 3.7.2 vs 3.6.6 (3.6.6 no longer linked on page)
- add 3.10.0 links
- correct spelling of sc3-plugins
- make external links open in new tab/window
- redirect sc3-plugins link to new site

several of these points are up for discussion. i just thought the
windows release links were getting crowded with links to sc3-plugins,
and there's a link to it below anyway.