### PR TITLE
add macos ear damage warning

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -15,6 +15,9 @@
                     </li>
                 </ul>
                 <p>Supports macOS 10.13-10.15, earlier versions of macOS may work</p>
+                <div class="alert alert-warning" role="alert">
+                    CAUTION: macOS system volume doesn’t effectively limit audio applications’ maximum volume. Extra care has to be put in working on this platform, especially with headphones, because programs can produce unexpectedly loud sounds regardless of system volume settings, potentially causing ear damage. As a safety measure, we highly recommend to install the <a href="" title="SafetyNet quark">SafetyNet</a> quark. See <a href="https://doc.sccode.org/Guides/UsingQuarks.html" title="Using Quarks">Using Quarks</a> for Quarks installation instruction.
+                </div>
                 <h4>Previous Releases</h4>
                 <ul class="nodot">
                     <li>


### PR DESCRIPTION
After a request from users on the forum, here is a proposal for adding a warning for ear damage under macos downoad page, with recommendation to install the SafetyNet quark, and a link to Quarks installation instructions.

Forum discussion: https://scsynth.org/t/way-to-limit-maximum-output-volume
Issue with CoreAudio not clipping/limit the output range: https://github.com/supercollider/supercollider/issues/4894