### PR TITLE
update downloads page for 3.11.2

### DIFF
--- a/_includes/download.md
+++ b/_includes/download.md
@@ -8,24 +8,18 @@
                 <h4>Current Version</h4>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-macOS-signed.zip"><i class="icon-download-alt">.</i> 3.11.1 - signed, notarized</a> (sn*)
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-macOS-signed.zip"><i class="icon-download-alt">.</i> 3.11.2 - signed, notarized (macOS 10.13-10.15)</a> (sn*)
                     </li>
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-macOS.zip"><i class="icon-download-alt">.</i> 3.11.1</a> (sn*)
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-macOS-legacy-signed.zip"><i class="icon-download-alt">.</i> 3.11.2 - legacy (macOS 10.10-10.12)</a> (sn*)
                     </li>
                 </ul>
-                <p>Supports macOS 10.13-10.15, earlier versions of macOS may work; macOS 11 (Big Sur) is currently <b>not</b> supported</p>
+                <p>macOS 11 Big Sur is currently <b>not</b> supported</p>
                 <div class="alert alert-warning" role="alert">
                     CAUTION: macOS system volume doesn’t effectively limit audio applications’ maximum volume. Extra care has to be put in working on this platform, especially with headphones, because programs can produce unexpectedly loud sounds regardless of system volume settings, potentially causing ear damage. As a safety measure, we highly recommend to install the <a href="" title="SafetyNet quark">SafetyNet</a> quark. See <a href="https://doc.sccode.org/Guides/UsingQuarks.html" title="Using Quarks">Using Quarks</a> for Quarks installation instruction.
                 </div>
                 <h4>Previous Releases</h4>
                 <ul class="nodot">
-                    <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.0/SuperCollider-3.11.0-macOS-signed.zip"><i class="icon-download-alt">.</i> 3.11.0 - signed, notarized</a> (sn*)
-                    </li>
-                    <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.0/SuperCollider-3.11.0-macOS.zip"><i class="icon-download-alt">.</i> 3.11.0</a> (sn*)
-                    </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.4/SuperCollider-3.10.4-macOS-signed.zip"><i class="icon-download-alt">.</i> 3.10.4 - signed</a> (sn*)
                     </li>
@@ -59,10 +53,10 @@
                 </h4>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-Source.tar.bz2">3.11.1 source tarball</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-Source.tar.bz2">3.11.2 source tarball</a>
                     </li>
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-Source.tar.bz2">3.11.1 GPG signature</a>
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-Source.tar.bz2">3.11.2 GPG signature</a>
                     </li>
                 </ul>
                 <p>Builds with gcc >= 4.9</p>
@@ -114,21 +108,15 @@
                 <h4>Current Version</h4>
                 <ul class="nodot">
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-Windows-64bit-VS.exe"><i class="icon-download-alt">.</i> 3.11.1, 64-bit</a><br />
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-Windows-64bit-VS.exe"><i class="icon-download-alt">.</i> 3.11.2, 64-bit</a><br />
                     </li>
                     <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.1/SuperCollider-3.11.1-Windows-32bit-VS.exe"><i class="icon-download-alt">.</i> 3.11.1, 32-bit</a><br />
+                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-Windows-32bit-VS.exe"><i class="icon-download-alt">.</i> 3.11.2, 32-bit</a><br />
                     </li>
                 </ul>
                 <p>Supports Windows Vista, 7, 8, 10</p>
                 <h4>Previous releases</h4>
                 <ul class="nodot">
-                    <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.0/SuperCollider-3.11.0_Release-x64-VS-e341b49.exe"><i class="icon-download-alt">.</i> 3.11.0, 64-bit</a><br />
-                    </li>
-                    <li>
-                        <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.11.0/SuperCollider-3.11.0_Release-x86-VS-e341b49.exe"><i class="icon-download-alt">.</i> 3.11.0, 32-bit</a><br />
-                    </li>
                     <li>
                         <a href="https://github.com/supercollider/supercollider/releases/download/Version-3.10.4/SuperCollider-3.10.4_Release-x64-VS-95e9507.exe"><i class="icon-download-alt">.</i> 3.10.4, 64-bit</a><br />
                     </li>


### PR DESCRIPTION
i also removed the 3.11.0 links; since the 3.11.2 release covers back to macOS 10.10 now there's not much of a reason
to keep the 3.11.0 artifacts up. i think it may have been a mistake originally anyway.