### PR TITLE
Update news archive

### DIFF
--- a/_posts/2019-01-17-supercollider-3.10.1.md
+++ b/_posts/2019-01-17-supercollider-3.10.1.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.10.1"
+description: "SuperCollider 3.10.1 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.10.1! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.10.1).
+
+Thanks for using SuperCollider!

--- a/_posts/2019-02-08-supercollider-3.10.2.md
+++ b/_posts/2019-02-08-supercollider-3.10.2.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.10.2"
+description: "SuperCollider 3.10.2 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.10.2! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.10.2).
+
+Thanks for using SuperCollider!

--- a/_posts/2019-08-30-supercollider-3.10.3.md
+++ b/_posts/2019-08-30-supercollider-3.10.3.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.10.3"
+description: "SuperCollider 3.10.3 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.10.3! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.10.3).
+
+Thanks for using SuperCollider!

--- a/_posts/2020-01-16-supercollider-3.10.4.md
+++ b/_posts/2020-01-16-supercollider-3.10.4.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.10.4"
+description: "SuperCollider 3.10.4 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.10.4! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.10.4).
+
+Thanks for using SuperCollider!

--- a/_posts/2020-03-22-supercollider-3.11.0.md
+++ b/_posts/2020-03-22-supercollider-3.11.0.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.11.0"
+description: "SuperCollider 3.11.0 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.11.0! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.11.0).
+
+Thanks for using SuperCollider!

--- a/_posts/2020-04-21-supercollider-3.11.1.md
+++ b/_posts/2020-04-21-supercollider-3.11.1.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.11.1"
+description: "SuperCollider 3.11.1 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.11.1! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.11.1).
+
+Thanks for using SuperCollider!

--- a/_posts/2020-11-14-supercollider-3.11.2.md
+++ b/_posts/2020-11-14-supercollider-3.11.2.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "SuperCollider 3.11.2"
+description: "SuperCollider 3.11.2 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are proud to announce the release of SuperCollider 3.11.2! You can grab it from the [release page](https://github.com/supercollider/supercollider/releases/tag/Version-3.11.2).
+
+Thanks for using SuperCollider!

--- a/_posts/2021-08-02-supercollider-3.12.0.md
+++ b/_posts/2021-08-02-supercollider-3.12.0.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "SuperCollider 3.12.0"
+description: "SuperCollider 3.12.0 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are pleased to announce the release of SuperCollider 3.12.0! The release is available here: https://github.com/supercollider/supercollider/releases/tag/Version-3.12.0
+
+CHANGELOG.md contains a more extensive list of changes. Notable improvements in this version include:
+
+- Supernova is now available on Windows
+- Supercollider is officially supported on Bela platform
+- macOS Big Sur is now fully supported
+- On macOS output signal won't go over the system volume level
+- The `method not found` error in sclang now provides suggestions, using fuzzy array comparisons
+- Oppressive terminology has been updated throughout the project
+- CI has been updated to use GitHub Actions and now also runs our test suite
+
+Big thanks to everyone who contributed to this release!


### PR DESCRIPTION
I've updated the news archive with rudimentary entries for past releases (minor and bugfix), as well as for the current 3.12.0 release. Let me know if anything needs changing.

I've built the site locally and spot-checked it, looks fine to me.