### PR TITLE
fix: greenwashing link

### DIFF
--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -1,7 +1,7 @@
 - title: Greenwashing
   type: image
   image: greenwashing.jpg
-  link: https://frerikolofsson.com/music
+  link: https://fredrikolofsson.com/music/#greenwashing
   author: Fredrik Olofsson
   text: |
     An audiovisual piece in which we look at the invisible and listen to the inaudible.


### PR DESCRIPTION
added missing `d` in name/url and added project specific #target 