### PR TITLE
Switch to supercollider.online as domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+supercollider.online


### PR DESCRIPTION
Also see

* https://scsynth.org/t/moving-the-supercollider-webpage/
* https://github.com/supercollider/supercollider/issues/6114

Although GitHub is a convenient platform for developers, SuperCollider should not bound itself too much to GitHub.
Especially any outside communication should be always independent of GitHub, or any coding platform as history has shown ( <https://supercollider.sourceforge.net/>), as this is a part which.
Setting up a domain is an easy task and does not consume too much resources, therefore I decided to donate an official domain to SuperCollider.
I am happy to share any admin rights of the URL with the maintainers through OVH IAM management (see scsynth post) in order to be more resilient if for example I will be indefinitely absent from the community.

There are already some other websites which are operating under this domain, such as

* https://docs.supercollider.online/
* https://baryon.supercollider.online/
* https://quarks.supercollider.online/ (will be deprecated soon in favor of baryon)

I already setup the A record for the domain, so that once the branch is deployed the website would be available under <https://supercollider.online>.

If deployed, the "old" domain <https://supercollider.github.io/> will automatically redirected to the new domain <https://supercollider.online>, see https://capital-g.github.io/quarks-web/ which now redirects automatically to https://quarks.supercollider.online/
