### PR TITLE
Add link to docs in navbar

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -6,6 +6,8 @@
   page: examples
 - title: Projects
   page: projects
+- title: Documentation
+  href: https://docs.supercollider.online
 - title: Links
   page: links
 - title: github


### PR DESCRIPTION
Proposal to add a link to the official docs in the navbar - I think this is rather common among project websites.
With the change it would look like this.

![image](https://github.com/supercollider/supercollider.github.io/assets/8267062/29f7d07f-7ffa-4605-b680-77e66bff7bfb)
