### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'bundler'
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Makes it easier to keep the dependencies of the website up to date and be aware when something breaks.