### PR TITLE
Add download link for nightly macOS arm build

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -41,9 +41,9 @@ os:
         end_text: This is the latest build of the development branch.
         downloads:
           - name: Latest x64 build
-            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx-x64/develop-latest.html
+            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/macos-x64/develop-latest.html
           - name: Latest arm build
-            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx-arm64/develop-latest.html
+            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/macos-arm64/develop-latest.html
 
   - name: Linux
     slug: Linux

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -40,8 +40,10 @@ os:
         name: Bleeding Edge
         end_text: This is the latest build of the development branch.
         downloads:
-          - name: Latest build
-            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx/develop-latest.html
+          - name: Latest x64 build
+            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx-x64/develop-latest.html
+          - name: Latest arm build
+            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/osx-arm64/develop-latest.html
 
   - name: Linux
     slug: Linux


### PR DESCRIPTION
Implements https://github.com/supercollider/supercollider.github.io/issues/285

This needs to be coordinated with https://github.com/supercollider/supercollider/pull/6593

