### PR TITLE
Remove 32 bit windows nightly download

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -127,5 +127,3 @@ os:
         downloads:
           - name: Latest build (x64)
             link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win64/develop-latest.html
-          - name: Latest build (x86)
-            link: http://supercollider.s3.amazonaws.com/builds/supercollider/supercollider/win32/develop-latest.html


### PR DESCRIPTION
As requested in https://github.com/supercollider/supercollider.github.io/issues/285#issuecomment-2599509928

Will be removed b/c we don't upload a 32 bit windows build anymore, see https://github.com/supercollider/supercollider/commit/f86408abd154fa50cb1d44a28aed7561281b6ed6