### PR TITLE
Make audio player take full width

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -491,3 +491,7 @@ svg {
     max-height: 15em;
   }
 }
+
+audio {
+  width: 100%;
+}


### PR DESCRIPTION
current

<img width="905" alt="grafik" src="https://github.com/user-attachments/assets/1056e758-3ed3-42c9-a1fc-6bc9f24906f3" />

vs new

<img width="969" alt="grafik" src="https://github.com/user-attachments/assets/8749d9d4-08da-4f39-9d77-9a7956cf813c" />
