### PR TITLE
Remove features header

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: index
 bootstrap: true
 ---
 
-{% include section.html title="Features" src="features.md" md=1 %}
+{% include section.html src="features.md" md=1 %}
 
 {% include section.html title="Downloads" src="downloads.md" md=1 css="downloads" %}
 


### PR DESCRIPTION
Seems a bit redundant to me for the initial introduction on the website?

current

<img width="1151" alt="grafik" src="https://github.com/user-attachments/assets/df102221-f293-4909-a26c-17f8c72b0a91" />


vs new

<img width="1105" alt="grafik" src="https://github.com/user-attachments/assets/646c4c8d-0656-445c-9ebb-baf5a35cfba0" />
