### PR TITLE
Fix toggle theme button

### DIFF
--- a/_includes/default/navbar.html
+++ b/_includes/default/navbar.html
@@ -35,8 +35,16 @@
         </a>
       </li>
       {% endfor %}
-      <li>
-        <a id="theme-toggle" aria-label="Theme Toggle" onclick="themeToggle()" title="Toggle between Light and Dark theme"></a>
+      <li class="icon">
+        <a
+          class="icon"
+          id="theme-toggle"
+          aria-label="Theme Toggle"
+          onclick="themeToggle()"
+          title="Toggle between light and dark theme"
+        >
+          <i class="fa-solid fa-circle-half-stroke"></i>
+        </a>
       </li>
     </ul>
 


### PR DESCRIPTION
We have a light/dark button but it was not attached to an icon and therefore not clickable. This PR fixes this.

<img width="268" alt="grafik" src="https://github.com/user-attachments/assets/4220423b-7f43-47b6-83de-2bb91f61a47c" />

Light theme

![grafik](https://github.com/user-attachments/assets/3ba33ad0-342c-4f8a-b809-b9933012adbe)

Dark theme

![grafik](https://github.com/user-attachments/assets/3072403c-7be6-4a22-9813-c048b6ed5574)


