### PR TITLE
Make Snippet take full width

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -225,7 +225,7 @@ nav {
 
 .snippet {
   margin-top: 3em;
-  max-width: 100%;
+  width: 100%;
   h4.snippet-title {
     font-size: 1.1rem;
     span {


### PR DESCRIPTION
Currently

![grafik](https://github.com/user-attachments/assets/8e988d38-640d-46bc-8498-70adbece9fba)

w/ this PR

![grafik](https://github.com/user-attachments/assets/fae77fac-8c30-4d16-9e7f-a1ecb67324ba)

edit: PR screenshot uses dark theme and has #291 not included, although this would be included after a merge