### PR TITLE
Group downloads via tabs

### DIFF
--- a/_includes/default/head.html
+++ b/_includes/default/head.html
@@ -46,12 +46,12 @@
     {% if site.bootstrap %}
     <!-- Bootstrap-4.1.3 isolation CSS -->
     <link rel="stylesheet" type="text/css" href="{{ '/assets/css/vendor/bootstrap-iso.min.css' | relative_url }}">
-    <!-- JQuery 3.3.1 -->
-    <script defer src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <!-- Bootstrap 4.1.3 compiled and minified JavaScript -->
-    <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-    <!-- Popper, a dependency of Bootstrap-->
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+
+    <!-- see https://getbootstrap.com/docs/4.6/getting-started/introduction/#separate -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+    
     {% endif %}
 
     <!-- KaTeX 0.13.9 -->

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -86,6 +86,10 @@ h1, h2, h3, h4, h5 {
   }
 }
 .downloads {
+  ul#osTab {
+    margin: auto;
+    margin-bottom: 2vh;
+  }
   div.card {
     background: transparent;
     border: 1px solid var(--border);

--- a/downloads.md
+++ b/downloads.md
@@ -1,51 +1,117 @@
 ---
 layout: page
 title: Downloads
+bootstrap: true
 ---
 
-Jump to:
-[Mac](#mac) - [Linux](#linux) - [Windows](#windows) - [Other Platforms](#other-platforms)
+Stable Releases, Betas, Release Candidates and Development builds are accessible via [GitHub releases](https://github.com/supercollider/supercollider/releases).
 
-------
+<ul class="nav nav-tabs" id="osTab" role="tablist">
+    {% for os in site.data.downloads.os %}
+        <li class="nav-item" role="presentation">
+            <button
+                class="nav-link {% if forloop.first %}active{% endif %}"
+                id="{{ os.slug | downcase }}-tab"
+                data-toggle="tab"
+                data-target="#{{ os.slug | downcase }}"
+                type="button"
+                role="tab"
+                aria-controls="{{ os.slug }}"
+                aria-selected="true"
+            >{{ os.slug }}
+            </button>
+        </li>
+    {% endfor %}
+    <li class="nav-item" role="presentation">
+        <button
+            class="nav-link"
+            id="other-tab"
+            data-toggle="tab"
+            data-target="#other"
+            type="button"
+            role="tab"
+            aria-controls="Other releases"
+            aria-selected="true"
+        >Other releases
+        </button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button
+            class="nav-link"
+            id="extensions-tab"
+            data-toggle="tab"
+            data-target="#extensions"
+            type="button"
+            role="tab"
+            aria-controls="Plugins And Extensions"
+            aria-selected="true"
+        >Plugins And Extensions
+        </button>
+    </li>
+</ul>
 
-{% for os in site.data.downloads.os %}
-## {{ os.slug }}
-{% for category in os.categories %}
-#### {{ category.name | capitalize }}
-{{ category.start_text }}
-{% for download in category.downloads %}
-- [{{ download.name }}]({{ download.link }})
-{% endfor %}
-{{ category.end_text }}
-{% endfor %}
-------
-{% endfor %}
-
-## Other Platforms
-
-SuperCollider can be used on embedded platforms, including Raspberry Pi and Beagle Bone Black.  
-See the [project READMEs](https://github.com/supercollider/supercollider) for more information.
-
-## Releases
-
-[SuperCollider releases](https://github.com/supercollider/supercollider/releases) (including Stable Releases, Betas, and Release Candidates).
-
-## Building From Source
-
-Build instruction can be found on [GitHub](https://github.com/supercollider/supercollider) in the README corresponding to your Operating System.
-
-## Plugins And Extensions
-
-#### SC3 Plugins
-
-[https://supercollider.github.io/sc3-plugins](https://supercollider.github.io/sc3-plugins)
-
-The sc3-plugins are extension plugins for the SuperCollider audio synthesis server.  
-These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.
-
-#### Quarks
-
-[https://github.com/supercollider-quarks/quarks](https://github.com/supercollider-quarks/quarks)
-
-Quarks are packages containing classes, extension methods, documentation and UGens.  
-The integrated Quarks package system is used to download and manage these packages on your system.
+<div class="tab-content" id="osTabContent">
+    {% for os in site.data.downloads.os %}
+        <div
+            class="tab-pane fade {% if forloop.first %}show active{% endif %}"
+            id="{{ os.slug | downcase }}"
+            role="tabpanel"
+            aria-labelledby="{{ os.slug }}-tab"
+        >
+            {% for category in os.categories %}
+                <b>{{ category.name | capitalize }}</b>
+                <p>{{ category.start_text }}</p>
+                <ul>
+                    {% for download in category.downloads %}
+                        <li>
+                            <a href="{{ download.link }}">
+                            {{ download.name }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <p>{{ category.end_text }}</p>
+            {% endfor %}
+        </div>
+    {% endfor %}
+    <div
+        class="tab-pane fade"
+        id="other"
+        role="tabpanel"
+        aria-labelledby="other-tab"
+    >
+        <b>Sources</b>
+        <p>
+            Build instruction can be found on <a href="https://github.com/supercollider/supercollider">GitHub</a> in the README corresponding to your Operating System.
+        </p>
+        <b>Other Platforms</b>
+        <p>
+            SuperCollider can be used on embedded platforms, including Raspberry Pi and Beagle Bone Black.
+            See the <a href="https://github.com/supercollider/supercollider">project READMEs</a> for more information.
+        </p>
+    </div>
+    <div
+        class="tab-pane fade"
+        id="extensions"
+        role="tabpanel"
+        aria-labelledby="extensions-tab"
+    >
+        <b>SC3 Plugins</b> 
+        <p>
+            <a href="https://supercollider.github.io/sc3-plugins">https://supercollider.github.io/sc3-plugins</a>
+        </p>
+        <p>
+            The sc3-plugins are extension plugins for the SuperCollider audio synthesis server.<br/>
+            These third-party plugins provide additional synthesis, analysis, and other capabilities for the sound server.
+        </p>
+        <hl/>
+        <b>Quarks</b><br/>
+        <p>
+            <a href="https://github.com/supercollider-quarks/quarks">https://github.com/supercollider-quarks/quarks</a>
+        </p>
+        <p>
+            Quarks are packages containing classes, extension methods, documentation and UGens.<br/>
+            The integrated Quarks package system is used to download and manage these packages on your system.
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
As platforms are more mutually exclusive I thought it would be better to organize the downloads in tabs instead of a long list

[Current](https://supercollider.github.io/downloads)

![grafik](https://github.com/user-attachments/assets/e581b34c-1402-4db3-8cfc-b3ebf41c5d18)
... long scrolling

This PR

![grafik](https://github.com/user-attachments/assets/105cb17e-51ca-437b-9e32-0b83dcc22d66)
