### PR TITLE
Add mastodon link

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -13,6 +13,9 @@
 - title: github
   icon: fab fa-github
   href: https://github.com/supercollider/supercollider
+- title: mastodon
+  icon: fab fa-mastodon
+  href: https://social.toplap.org/@supercollider
 - title: rss
   icon: fa fa-rss
   page: /feed.xml

--- a/community.md
+++ b/community.md
@@ -16,6 +16,7 @@ These communities are managed and moderated by a team that works closely with th
 [scsynth.org](https://scsynth.org) | The forum - this is the as _official_ as it gets in regards to SuperCollider community. It also offers multiple chat channels once you are registered.
 [sccode.org](https://sccode.org) | A community around sharing SuperCollider code snippets
 [github.com/supercollider](https://github.com/supercollider) | GitHub organization where SuperCollider is developed
+[social.toplap.org/@supercollider](https://social.toplap.org/@supercollider/) | Official Mastodon account
 
 ## Other communities
 


### PR DESCRIPTION
Add a link to the official mastodon account of SuperCollider located @ https://social.toplap.org/@supercollider/

Currently I have access to the account and it is associated with my private mail, but I am happy to share this account w/ other devs or community managers <3

Changes as screenshot

## Navbar
<img width="786" alt="grafik" src="https://github.com/user-attachments/assets/f499a022-6249-4db7-9716-0ac87212413f" />

## Communities page
<img width="1169" alt="grafik" src="https://github.com/user-attachments/assets/eb42787c-7f41-4180-8250-f0a97c87b609" />
