### PR TITLE
Update downloads and news for 3.14.0

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -9,13 +9,17 @@ os:
         name: Current Version
         end_text: macOS builds are signed and notarized
         downloads:
+          - name: 3.14.0 universal binary, macOS 11+
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.14.0/SuperCollider-3.14.0-macOS-universal.dmg
+          - name: 3.14.0 "legacy" x64, macOS 10.15+
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.14.0/SuperCollider-3.14.0-macOS-x64-legacy.dmg
+      - key: previous_releases
+        name: Previous Releases
+        downloads:
           - name: 3.13.0 universal binary, macOS 10.14 and later
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0-macOS-universal.dmg
           - name: 3.13.0 "legacy" x64, macOS 10.10-10.13
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0-macOS-x64-legacy.dmg
-      - key: previous_releases
-        name: Previous Releases
-        downloads:
           - name: 3.12.2 for macOS 10.13 and later
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.12.2/SuperCollider-3.12.2-macOS.dmg
           - name: 3.12.2 - legacy (macOS 10.10-10.12)
@@ -49,12 +53,12 @@ os:
       # The first download in this category will be shown on the index page
       - key: current_version
         name: Current Version
-        end_text: Build with gcc >= 6.3
+        end_text: Build with gcc >= 9
         downloads:
-          - name: 3.13.1 source tarball for Linux
-            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.1/SuperCollider-3.13.1-Source.tar.bz2
-          - name: 3.13.1 GPG signature
-            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.1/SuperCollider-3.13.1-Source.tar.bz2.asc
+          - name: 3.14.0 source tarball for Linux
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.14.0/SuperCollider-3.14.0-Source.tar.bz2
+          - name: 3.14.0 GPG signature
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.14.0/SuperCollider-3.14.0-Source.tar.bz2.asc
       - key: official_linux_packages
         name: Official Linux Packages
         downloads:
@@ -88,18 +92,20 @@ os:
       # The first download in this category will be shown on the index page
       - key: current_version
         name: Current Version
-        end_text: Supports Windows 7, 8, 10
+        end_text: Supports Windows 10, 11
         downloads:
-          - name: 3.13.0 for Windows 64-bit
-            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0_Release-x64-VS-3188503.exe
-          - name: 3.13.0 for Windows 32-bit
-            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0_Release-x86-VS-3188503.exe
+          - name: 3.14.0, x64
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.14.0/SuperCollider-3.14.0_Release-x64-VS-d263b8c.exe
       - key: previous_releases
         name: Previous Releases
         downloads:
-          - name: 3.12.2 for Windows 64-bit
+          - name: 3.13.0, 64-bit
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0_Release-x64-VS-3188503.exe
+          - name: 3.13.0, 32-bit
+            link: https://github.com/supercollider/supercollider/releases/download/Version-3.13.0/SuperCollider-3.13.0_Release-x86-VS-3188503.exe
+          - name: 3.12.2, 64-bit
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.12.2/SuperCollider-3.12.2_Release-x64-VS-7c4c983.exe
-          - name: 3.12.2 for Windows 32-bit
+          - name: 3.12.2, 32-bit
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.12.2/SuperCollider-3.12.2_Release-x86-VS-7c4c983.exe
           - name: 3.11.2, 64-bit
             link: https://github.com/supercollider/supercollider/releases/download/Version-3.11.2/SuperCollider-3.11.2-Windows-64bit-VS.exe

--- a/_posts/2025-07-26-supercollider-3.14.0.md
+++ b/_posts/2025-07-26-supercollider-3.14.0.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "SuperCollider 3.14.0"
+description: "SuperCollider 3.14.0 now available"
+category: Releases
+author: dyfer
+tags: []
+---
+
+We are pleased to announce the release of SuperCollider 3.14.0! The release is available here: https://github.com/supercollider/supercollider/releases/tag/Version-3.14.0
+
+This version has a number of changes since SC 3.13. Highlights include:
+
+- Sclang functions now support collecting arbitrary keyword arguments via `{ |...args, kwargs| kwargs }`
+- The initialization sample of multiple UGens was fixed
+- Documentation can now also be themed like the IDE
+- Due to updated bundled boost libraries on macOS and Windows, FluCoMa UGens which were working under SuperCollider 3.13 are not compatible anymore with 3.14! Go to https://github.com/flucoma/flucoma-sc to check for compatible version.
+  - This does not apply to other extensions - e.g. sc3-plugins version 3.13 will still work with SuperCollider 3.14, as the plugin interface was not changed
+- Even though these are not as much of user-facing changes, there were countless structural upgrades: we migrated to Qt6, added and improved tests, updated 3rd-party libraries, updated the build system for most recent build tools, and adapted a new organizational structure for development
+
+A big thank you to all developers for your contributions!


### PR DESCRIPTION
Note that I cleaned up old entires a bit:

- old Windows entries now state  `3.x.x, 64-bit` and `3.x.x, 32-bit`
- 3.14.0 states `3.14.0, x64` (anticipating possible future publication of arm64 builds)
- I updated supported Windows versions and GCC version