### PR TITLE
Fix community page link casing

### DIFF
--- a/_includes/community.md
+++ b/_includes/community.md
@@ -1,5 +1,5 @@
 SuperCollider is a community project and there are several communities to join.
-For an incomplete list, take a look at the [communities site](Community).
+For an incomplete list, take a look at the [communities site](community).
 
 A good place to start is _the forum_ located at [scsynth.org](https://scsynth.org).
 


### PR DESCRIPTION
This changes the communities site link in _includes/community.md from Community to community.

The current link resolves to /Community, which 404s on the published site because the page lives at /community.