### PR TITLE
Fix upstream theme version to v2.5.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,11 @@ plugins:
   - jekyll-feed
   - jekyll-remote-theme
 
-remote_theme: sylhare/type-on-strap
+# keep below 2.5.0 b/c 2.5.1 removed bootstrap iso css
+# which either breaks the tabs from the download section
+# or the dark mode, see
+# https://github.com/sylhare/Type-on-Strap/pull/549
+remote_theme: sylhare/type-on-strap@v2.5.0
 
 # Theme settings
 color_theme: auto


### PR DESCRIPTION
v2.5.1 of our Type-On-Strap removes vendored bootstrap-iso css, which breaks the tabs functionality of the downloads page.
Re-introducing bootstrap 4.1.3 via a cdn breaks the dark theme though...

For a quick fix now, we can just stay below 2.5.1 for now - it is probably a good idea to keep this on a fixed version nonetheless, as otherwise each deployment can break the website.

For further details see https://github.com/supercollider/supercollider.github.io/issues/314
Please do not apply any kind of dependabot on the theme until #314 gets fixed!