### PR TITLE
Fix bootstrap isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site/
 vendor/
 _config-dev.yml
 .DS_Store
+.sass-cache
+_site_*

--- a/_config.yml
+++ b/_config.yml
@@ -25,11 +25,7 @@ plugins:
   - jekyll-feed
   - jekyll-remote-theme
 
-# keep below 2.5.0 b/c 2.5.1 removed bootstrap iso css
-# which either breaks the tabs from the download section
-# or the dark mode, see
-# https://github.com/sylhare/Type-on-Strap/pull/549
-remote_theme: sylhare/type-on-strap@v2.5.0
+remote_theme: sylhare/type-on-strap
 
 # Theme settings
 color_theme: auto

--- a/_includes/default/head.html
+++ b/_includes/default/head.html
@@ -34,6 +34,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Source+Code+Pro:wght@400;600&family=JetBrains+Mono:wght@600;700&family=Raleway:wght@900&display=swap" rel="stylesheet">
 
+    {% if site.bootstrap %}
+    <!-- Bootstrap 4.6.2 CSS CDN - loaded in a @layer so theme styles always take precedence -->
+    <style>@import url("https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css") layer(bootstrap);</style>
+    {% endif %}
+
     <!-- CSS -->
     <link rel="stylesheet" href="{{ '/assets/css/main.css?v=' | append: site.site_version | relative_url }}">
 
@@ -44,9 +49,6 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.title | default: 'SuperCollider latests posts' }}" href="{{ 'feed.xml' | absolute_url }}"/>
 
     {% if site.bootstrap %}
-    <!-- Bootstrap-4.1.3 isolation CSS -->
-    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/vendor/bootstrap-iso.min.css' | relative_url }}">
-
     <!-- see https://getbootstrap.com/docs/4.6/getting-started/introduction/#separate -->
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>

--- a/_includes/default/head.html
+++ b/_includes/default/head.html
@@ -36,6 +36,7 @@
 
     {% if site.bootstrap %}
     <!-- Bootstrap 4.6.2 CSS CDN - loaded in a @layer so theme styles always take precedence -->
+    <style>@layer reset, bootstrap;</style>
     <style>@import url("https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css") layer(bootstrap);</style>
     {% endif %}
 


### PR DESCRIPTION
@capital-G 
Theme has been updated (https://github.com/sylhare/Type-on-Strap/pull/574)
This should make it work:

<img width="1164" height="450" alt="image" src="https://github.com/user-attachments/assets/c73e007f-faad-4cd3-8292-bbdcef06fdba" />

<img width="1793" height="567" alt="image" src="https://github.com/user-attachments/assets/df593479-27ec-45f0-9c50-f984604cc3bd" />

Review it carefully let me know if you see any upstream based problems.

Fix #314 